### PR TITLE
アサイン可能なissueを集めて一覧を記事に投稿するをカテゴリー毎に表示を分割する

### DIFF
--- a/postAssignableIssues/README.md
+++ b/postAssignableIssues/README.md
@@ -7,5 +7,5 @@
 ```
 $ export GITHUB_APP_PRIVATE_KEY=$(cat private-key.pem)
 
-$ gcloud functions deploy PostAssignableIssuesPubSub --set-env-vars GITHUB_APP_PRIVATE_KEY=$GITHUB_APP_PRIVATE_KEY,GITHUB_APP_ID=$GITHUB_APP_ID,GITHUB_OWNER=$GITHUB_OWNER,INSTALLATION_ID=$INSTALLATION_ID,VERIFY_ID_TOKEN=$VERIFY_ID_TOKEN,NOTE_TOKEN=$NOTE_TOKEN,NOTE_ID=$NOTE_ID,NOTE_HOST=$NOTE_HOST --runtime go116 --trigger-resource post_assignable_issues --trigger-event google.pubsub.topic.publish --region asia-northeast1
+$ gcloud functions deploy PostAssignableIssuesPubSub --set-env-vars GITHUB_APP_PRIVATE_KEY=$GITHUB_APP_PRIVATE_KEY,GITHUB_APP_ID=$GITHUB_APP_ID,GITHUB_OWNER=$GITHUB_OWNER,INSTALLATION_ID=$INSTALLATION_ID,NOTE_TOKEN=$NOTE_TOKEN,NOTE_ID=$NOTE_ID,NOTE_HOST=$NOTE_HOST --runtime go116 --trigger-resource post_assignable_issues --trigger-event google.pubsub.topic.publish --region asia-northeast1
 ```

--- a/postAssignableIssues/function.go
+++ b/postAssignableIssues/function.go
@@ -41,7 +41,7 @@ func PostAssignableIssuesPubSub(ctx context.Context, m *pubsub.Message) error {
 		return err
 	}
 
-	repositories := []string{"gas-tools"}
+	repositories := []string{"tool-test"}
 	text := ""
 
 	for _, rep := range repositories {

--- a/postAssignableIssues/function.go
+++ b/postAssignableIssues/function.go
@@ -2,7 +2,6 @@ package postAssignableIssues
 
 import (
 	"context"
-	"log"
 	"net/http"
 	"os"
 	"strconv"
@@ -11,10 +10,9 @@ import (
 	"github.com/bradleyfalzon/ghinstallation"
 )
 
-type Data struct {
+type IssueConfig struct {
 	Repository string
-	Name       string
-	Labels     []string
+	Categories []string
 }
 
 func PostAssignableIssuesPubSub(ctx context.Context, m *pubsub.Message) error {
@@ -41,14 +39,18 @@ func PostAssignableIssuesPubSub(ctx context.Context, m *pubsub.Message) error {
 		return err
 	}
 
-	repositories := []string{"tool-test"}
+	items := []IssueConfig{{
+		Repository: "tool-test",
+		Categories: []string{"RFP", "ドキュメンテーション", "設計前", "運用改善"},
+	}}
 	text := ""
 
-	for _, rep := range repositories {
+	for _, item := range items {
 		r := Request{
 			Token:      token,
 			Owner:      os.Getenv("GITHUB_OWNER"),
-			Repository: rep,
+			Repository: item.Repository,
+			Categories: item.Categories,
 		}
 
 		t, err := GetIssueText(r)
@@ -68,8 +70,6 @@ func PostAssignableIssuesPubSub(ctx context.Context, m *pubsub.Message) error {
 	if err := PostNote(rn); err != nil {
 		return err
 	}
-
-	log.Println("OK")
 
 	return nil
 }

--- a/postAssignableIssues/issue.go
+++ b/postAssignableIssues/issue.go
@@ -16,6 +16,7 @@ type GitHubConfig struct {
 	Token      string
 	Owner      string
 	Repository string
+	Categories []string
 }
 
 type IssuesNodes struct {
@@ -54,6 +55,7 @@ type Request struct {
 	Token      string
 	Owner      string
 	Repository string
+	Categories []string
 }
 
 type TempleIssueData struct {
@@ -74,14 +76,12 @@ func GetIssueText(r Request) (string, error) {
 		return "", err
 	}
 
-	categories := []string{"RFP", "ドキュメンテーション", "設計前", "運用改善"}
-
 	t := TempleData{
 		Repository: r.Repository,
 	}
 
 	for _, is := range iss {
-		for _, c := range categories {
+		for _, c := range r.Categories {
 			if is.isTempleIssueLabel(c) {
 				tis := TempleIssueData{
 					Category: c,
@@ -235,7 +235,7 @@ func (t *TempleData) ToCategoryBody(category string) (string, error) {
 	text := `
 #### {{ .Category }}
 {{range $index, $is := .Issues}}
- - [{{ $is.Title }}]({{ $is.URL }}){{end}}
+ - {{ if $is.Milestone.Title }}【{{$is.Milestone.Title}}】{{ end }}[{{ $is.Title }}]({{ $is.URL }}){{end}}
 `
 
 	tpl, err := template.New("").Parse(text)


### PR DESCRIPTION
#82 

以下で作成した仕組みを拡張する
 - https://github.com/wheatandcat/gas-tools/pull/80

## ラベルのルール

以下のラベル毎にカテゴリーを分けて表示

|  ラベル名  |  内容  |
| ---- | ---- |
|  RFP  |  Request For Proposalの略。問題を記載しているのでプロポーザルを記載して全体に共有する  |
| ドキュメンテーション  |  ドキュメントにまとめて共有する  |
| 設計前  |  機能の設計書を作成する  |
| 運用改善 |  運用改善系/効率化の対応 |

## マイルストーンのルール

マイルストーンの設定しているissueはリリース日が決まっているものなので、マイルストーンのタイトルを表示